### PR TITLE
Ctrl+Digit2 -> Ctrl+2 to look like Ctrl+3 and Ctrl+4.

### DIFF
--- a/source/editor/plugins/colibri/src/ui/ide/actions/ColibriCommands.ts
+++ b/source/editor/plugins/colibri/src/ui/ide/actions/ColibriCommands.ts
@@ -252,12 +252,14 @@ namespace colibri.ui.ide.actions {
 
             manager.addKeyBinding(CMD_EDITOR_TABS_SIZE_DOWN, new commands.KeyMatcher({
                 control: true,
-                key: "3"
+                key: "Digit3",
+                keyLabel: "3",
             }));
 
             manager.addKeyBinding(CMD_EDITOR_TABS_SIZE_UP, new commands.KeyMatcher({
                 control: true,
-                key: "4"
+                key: "Digit4",
+                keyLabel: "4",
             }));
 
             // close editor


### PR DESCRIPTION
KeyMatches.ts line 63 seems to be happy with Ctrl+2 as much as with Ctrl+Digit2 as the
key specification.