### PR TITLE
Consistent use of "Import" throughout editors

### DIFF
--- a/source/editor/plugins/phasereditor2d.pack/src/AssetPackPlugin.ts
+++ b/source/editor/plugins/phasereditor2d.pack/src/AssetPackPlugin.ts
@@ -177,8 +177,8 @@ namespace phasereditor2d.pack {
                         command: {
                             id: CMD_ASSET_PACK_EDITOR_ADD_FILE,
                             icon: colibri.Platform.getWorkbench().getWorkbenchIcon(colibri.ICON_PLUS),
-                            name: "Add File",
-                            tooltip: "Add new file configuration",
+                            name: "Import File",
+                            tooltip: "Import a new file into the project by adding an entry for it to this Asset Pack.",
                             category: CAT_ASSET_PACK
                         },
                         handler: {

--- a/source/editor/plugins/phasereditor2d.pack/src/ui/editor/AssetPackEditor.ts
+++ b/source/editor/plugins/phasereditor2d.pack/src/ui/editor/AssetPackEditor.ts
@@ -250,7 +250,8 @@ namespace phasereditor2d.pack.ui.editor {
             const manager = new controls.ToolbarManager(parent);
 
             manager.addAction({
-                text: "Add File",
+                text: "Import File",
+				tooltip: "Import a new file into the project by adding an entry for it to this Asset Pack.",
                 icon: colibri.ColibriPlugin.getInstance().getIcon(colibri.ICON_PLUS),
                 callback: () => this.openAddFileDialog()
             });

--- a/source/editor/plugins/phasereditor2d.pack/src/ui/editor/ImportFileSection.ts
+++ b/source/editor/plugins/phasereditor2d.pack/src/ui/editor/ImportFileSection.ts
@@ -7,7 +7,7 @@ namespace phasereditor2d.pack.ui.editor {
     export class ImportFileSection extends controls.properties.PropertySection<io.FilePath> {
 
         constructor(page: controls.properties.PropertyPage) {
-            super(page, "phasereditor2d.pack.ui.editor.ImportFileSection", "Import File", false);
+            super(page, "phasereditor2d.pack.ui.editor.ImportFileSection", "Asset Pack Entry", false);
         }
 
         createForm(parent: HTMLDivElement) {
@@ -38,7 +38,7 @@ namespace phasereditor2d.pack.ui.editor {
 
                     const btn = document.createElement("button");
 
-                    btn.innerText = `Import ${importData.importer.getType()} (${importData.files.length})`;
+                    btn.innerText = `Import as ${importData.importer.getType()} (${importData.files.length})`;
 
                     btn.addEventListener("click", async (e) => {
 

--- a/source/editor/plugins/phasereditor2d.pack/src/ui/properties/AddFileToPackFileSection.ts
+++ b/source/editor/plugins/phasereditor2d.pack/src/ui/properties/AddFileToPackFileSection.ts
@@ -6,7 +6,7 @@ namespace phasereditor2d.pack.ui.properties {
     export class AddFileToPackFileSection extends controls.properties.PropertySection<io.FilePath> {
 
         constructor(page: controls.properties.PropertyPage) {
-            super(page, "phasereditor2d.pack.ui.properties.AddFileToPackFileSection", "Asset Pack File", false);
+            super(page, "phasereditor2d.pack.ui.properties.AddFileToPackFileSection", "Asset Pack Entry", false);
         }
 
         private async getPackItems(finder: core.PackFinder) {
@@ -76,7 +76,7 @@ namespace phasereditor2d.pack.ui.properties {
 
                         const btn = document.createElement("button");
 
-                        btn.innerText = `Import ${importData.importer.getType()} (${importData.files.length})`;
+                        btn.innerText = `Import as ${importData.importer.getType()} (${importData.files.length})`;
 
                         btn.addEventListener("click", async (e) => {
 


### PR DESCRIPTION
Changed Asset Pack Editor's "Import File" to "Add File To This Asset Pack."
(This distinguishes it from the "Add File To Asset Pack" shown when a
file is selected in the Files pane which does not target the open
Editor's pack; but perhaps the 'This' is unnecessary.)

Changed the button text "Import as <type> (N)" to "Add as <type> (N)",
pluralizing the file type when N > 1, e.g. "Add as spritesheets (3)".

The above changes remove the "Import" verb from the UI, which was used
synonymously with "Add".  We could have gone the other way, changing
uses of "Add File" to "Import File" instead, but "Add" appears to be the
prevalent verb in other Editors ("Add Component", "Add Object".)

Changed the menu bar's "Add File" to "Add File To Asset Pack", to help
the user understand the context, and to distinguish it from "New File".
Added a tooltip to it.

Changed "Asset Pack File" Property Section title to "Add File To Asset
Pack" to align with the above.

Closes #170